### PR TITLE
Bump lua-resty-auto-ssl to version 0.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openresty/openresty:latest-xenial
 
-RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl 0.11.0
+RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl 0.11.1
 
 RUN openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj '/CN=sni-support-required-for-valid-ssl' -keyout /etc/ssl/resty-auto-ssl-fallback.key -out /etc/ssl/resty-auto-ssl-fallback.crt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openresty/openresty:latest-xenial
 
-RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl 0.10.6-1
+RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-auto-ssl 0.11.0
 
 RUN openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj '/CN=sni-support-required-for-valid-ssl' -keyout /etc/ssl/resty-auto-ssl-fallback.key -out /etc/ssl/resty-auto-ssl-fallback.crt
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,11 +3,21 @@ events {
 }
 
 http {
-  # The "auto_ssl" shared dict must be defined with enough storage space to
-  # hold your certificate data.
+  # The "auto_ssl" shared dict should be defined with enough storage space to
+  # hold your certificate data. 1MB of storage holds certificates for
+  # approximately 100 separate domains.
   lua_shared_dict auto_ssl 1m;
+  # The "auto_ssl" shared dict is used to temporarily store various settings
+  # like the secret used by the hook server on port 8999. Do not change or
+  # omit it.
+  lua_shared_dict auto_ssl_settings 64k;
 
-  # A DNS resolver must be defined for OSCP stapling to function.
+  # A DNS resolver must be defined for OCSP stapling to function.
+  #
+  # This example uses Google's DNS server. You may want to use your system's
+  # default DNS servers, which can be found in /etc/resolv.conf. If your network
+  # is not IPv6 compatible, you may wish to disable IPv6 results by using the
+  # "ipv6=off" flag (like "resolver 8.8.8.8 ipv6=off").
   resolver 8.8.8.8;
 
   # Initial setup tasks.
@@ -20,7 +30,6 @@ http {
     auto_ssl:set("allow_domain", function(domain)
       return true
     end)
-    auto_ssl:set("dir", "/tmp")
 
     auto_ssl:init()
   }
@@ -65,6 +74,12 @@ http {
   # Internal server running on port 8999 for handling certificate tasks.
   server {
     listen 127.0.0.1:8999;
+
+    # Increase the body buffer size, to ensure the internal POSTs can always
+    # parse the full POST contents into memory.
+    client_body_buffer_size 128k;
+    client_max_body_size 128k;
+
     location / {
       content_by_lua_block {
         auto_ssl:hook_server()


### PR DESCRIPTION
Upgrade to the latest version `0.11.1` to include the fix for the new Let's Encrypt agreement of 15 Nov'17

And update nginx.conf configuration accordingly